### PR TITLE
Added 16 Star No LBLJ Beginner route

### DIFF
--- a/LiveSplit.SM64.asl
+++ b/LiveSplit.SM64.asl
@@ -176,6 +176,10 @@ startup {
     settings.Add("ccm8Split", false, "CCM (8)", "stage16NoLbljSplit");
     settings.Add("ssl11Split", false, "SSL (11)", "stage16NoLbljSplit");
     settings.Add("lll12Split", false, "LLL (12)", "stage16NoLbljSplit");
+	
+	settings.Add("stage16NoLbljBeginnerSplit", false, "16 Star No LBLJ Beginner Stage Splits (No BitDW Red Coins)", "stage16Split");
+    settings.Add("ssl10BeginnerSplit", false, "SSL (10)", "stage16NoLbljBeginnerSplit");
+    settings.Add("lll11BeginnerSplit", false, "LLL (11)", "stage16NoLbljBeginnerSplit");
 
     settings.Add("settingsReset", true, "Reset Settings");
     settings.Add("gameResetReset", false, "Reset on Game Reset", "settingsReset");
@@ -374,6 +378,14 @@ split {
         return true;
     }
     if (settings["ddd16Split"] && levelChange && old.level == dddLevel && old.action == starGrabAction && current.stars == 16) {
+        return true;
+    }
+	
+	//16 Star Stage Beginner Splits
+	if (settings["ssl10BeginnerSplit"] && levelChange && old.level == sslLevel && old.action == starGrabAction && current.stars == 10) {
+        return true;
+    }
+    if (settings["lll11BeginnerSplit"] && levelChange && old.level == lllLevel && old.action == starGrabAction && current.stars == 11) {
         return true;
     }
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ The splitter can either start the timer when the game starts normally, but it ca
 ![image](https://user-images.githubusercontent.com/93740337/140610533-80ab2ba2-acc3-4bca-abfd-92ff8c8c87fe.png)
 
 ## 16 Star No LBLJ Beginner (No BitDW Red Coins)
-![image](https://user-images.githubusercontent.com/60489413/153926052-4ad44a72-f860-4b6e-a8f3-cd020291b555.png)
+![16StarNoLBLJBeginnerSettings](https://user-images.githubusercontent.com/60489413/153927050-a6f17ecb-ba50-439c-b816-a242d1e908d8.png)
 ![image](https://user-images.githubusercontent.com/60489413/153926120-457c8342-c545-43c2-a6f2-dbd519958b92.png)
-
 
 ## 16 Star LBLJ
 ![image](https://user-images.githubusercontent.com/93740337/140610687-a99dfa21-d8a3-408a-9c08-6998235c5276.png)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ The splitter can either start the timer when the game starts normally, but it ca
 ![image](https://user-images.githubusercontent.com/93740337/140610599-b6e1af1d-a660-432c-b458-5a6a1910c54f.png)
 ![image](https://user-images.githubusercontent.com/93740337/140610533-80ab2ba2-acc3-4bca-abfd-92ff8c8c87fe.png)
 
+## 16 Star No LBLJ Beginner (No BitDW Red Coins)
+![image](https://user-images.githubusercontent.com/60489413/153926052-4ad44a72-f860-4b6e-a8f3-cd020291b555.png)
+![image](https://user-images.githubusercontent.com/60489413/153926120-457c8342-c545-43c2-a6f2-dbd519958b92.png)
+
+
 ## 16 Star LBLJ
 ![image](https://user-images.githubusercontent.com/93740337/140610687-a99dfa21-d8a3-408a-9c08-6998235c5276.png)
 ![image](https://user-images.githubusercontent.com/93740337/140610660-d1bfe335-eabd-4812-91ec-80de64a46dfb.png)


### PR DESCRIPTION
Beginner route without BitDW red coins, instead getting the elevator star in HMC 
-> split on SSL 10 star
-> split on LLL 11 star

Added both the layout/split settings and the example config images for the readme.

Playtested with Project64 1.6 and LiveSplit 1.8.18.